### PR TITLE
BAU Allow setting of sparkjava port by env var or use default

### DIFF
--- a/src/main/java/uk/gov/di/cri/experian/kbv/api/ExperianApi.java
+++ b/src/main/java/uk/gov/di/cri/experian/kbv/api/ExperianApi.java
@@ -17,6 +17,8 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
+import java.util.Optional;
+
 public class ExperianApi {
     private final HealthCheckResource healthCheckResource;
     private final QuestionResource questionResource;
@@ -24,7 +26,7 @@ public class ExperianApi {
 
     public ExperianApi() {
         try {
-            Spark.port(8080);
+            Spark.port(Integer.valueOf(Optional.ofNullable(System.getenv("PORT")).orElse("8080")));
             ObjectMapper objectMapper = new ObjectMapper();
             objectMapper.registerModule(new JavaTimeModule());
 


### PR DESCRIPTION
Allow setting of the spark java port, which allows us to run the app locally on another port.

In PaaS it should be `8080` so that's the default.