### PR TITLE
KBV-192: Specify API with OpenAPI document

### DIFF
--- a/deploy/api.yaml
+++ b/deploy/api.yaml
@@ -1,0 +1,188 @@
+openapi: "3.0.1"
+info:
+  title: "Experian KBV Wrapper Api"
+  version: "1.0"
+x-amazon-apigateway-request-validators:
+  body:
+    validateRequestBody: true
+    validateRequestParameters: false
+paths:
+  /question_request:
+    post:
+      responses:
+        "201":
+          description: "201 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuestionRequest"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExperianKbvQuestionRetrievalFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+  /question_answer:
+    post:
+      responses:
+        "201":
+          description: "201 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuestionAnswerRequest"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExperianKbvQuestionAnswerFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+components:
+  schemas:
+    QuestionAnswerRequest:
+      type: "object"
+      required:
+        - urn
+        - authRefNo
+      properties:
+        urn:
+          description: Unique Reference Number - supplied to Experian IIQ Soap Webservice a guid which is the ipv-session-id
+          maxLength: 36
+          type: "string"
+        authRefNo:
+          description: Experian Reference Number - A unique identifier generated required for an ongoing transaction with Experian
+          maxLength: 10
+          type: "string"
+        questionAnswers:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuestionAnswer'
+    QuestionAnswer:
+      type: "object"
+      required:
+        - questionId
+        - answer
+      properties:
+        questionId:
+          description: The unique identifier for the question
+          maxLength: 6
+          type: "string"
+        answer:
+          description: Answer provided by the user
+          maxLength: 50
+          type: "string"
+    QuestionRequest:
+      required:
+        - "urn"
+        - "personIdentity"
+      type: "object"
+      properties:
+        urn:
+          description: Unique Reference Number - Supplied to Experian service and is the ipv-session-id
+          maxLength: 36
+          type: "string"
+        strategy:
+          description: Determines the answer to question ratio to success
+          maxLength: 25
+          type: "string"
+          example: "3 out of 4"
+        personIdentity:
+          $ref: '#/components/schemas/PersonIdentity'
+    PersonIdentity:
+      type: "object"
+      required:
+        - title
+        - firstName
+        - surname
+        - dateOfBirth
+        - addresses
+      properties:
+        title:
+          maxLength: 10
+          type: "string"
+        firstName:
+          type: "string"
+        middleNames:
+          type: "string"
+        surname:
+          maximum: 30
+          type: "string"
+        dateOfBirth:
+          type: "string"
+          format: "date"
+        addresses:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonAddress'
+    PersonAddress:
+      type: "object"
+      required:
+        - houseName
+        - postcode
+        - street
+        - townCity
+      properties:
+        houseNumber:
+          maxLength: 10
+          type: "string"
+        houseName:
+          maxLength: 50
+          type: "string"
+        flat:
+          maxLength: 30
+          type: "string"
+        street:
+          maxLength: 60
+          type: "string"
+        townCity:
+          maxLength: 30
+          type: "string"
+        postcode:
+          maxLength: 8
+          type: "string"
+        district:
+          maxLength: 35
+          type: "string"
+        dateMoveOut:
+          type: "string"
+          format: "date"
+        addressType:
+          type: "string"
+          enum:
+            - CURRENT
+            - PREVIOUS
+    Error:
+      title: "Error Schema"
+      type: "object"
+      properties:
+        message:
+          type: "string"
+
+
+
+
+

--- a/deploy/api.yaml
+++ b/deploy/api.yaml
@@ -7,7 +7,7 @@ x-amazon-apigateway-request-validators:
     validateRequestBody: true
     validateRequestParameters: false
 paths:
-  /question_request:
+  /question-request:
     post:
       responses:
         "201":
@@ -28,13 +28,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validators: "Validate body"
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExperianKbvQuestionRetrievalFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
-  /question_answer:
+  /question-answer:
     post:
       responses:
         "201":
@@ -55,6 +56,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validators: "Validate body"
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -12,9 +12,9 @@ Globals:
     Tracing: Active
     VpcConfig:
       SecurityGroupIds:
-        - sg-03a1efaf2fed58442
+        - sg-0baf479c53ac54f59
       SubnetIds:
-        - subnet-07fcf55b165be35ed
+        - subnet-08cd07453da63f873
 
 Parameters:
   Environment:
@@ -30,13 +30,33 @@ Parameters:
 
 Resources:
 
-  KbvApi:
+  ExperianKbvApi:
     Type: AWS::Serverless::Api
     Properties:
-      OpenApiVersion: 3.0.1
+      MethodSettings:
+        - LoggingLevel: INFO
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      AccessLogSetting:
+        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user","requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
+      TracingEnabled: true
+      Name: !Sub "ExperianKbvApi-${Environment}"
       StageName: !Ref Environment
+      OpenApiVersion: 3.0.1
+      DefinitionBody:
+        openapi: "3.0.1" # workaround to get `sam validate` to work
+        paths: # workaround to get `sam validate` to work
+          /never-created:
+            options: { } # workaround to get `sam validate` to work
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: './api.yaml'
+      EndpointConfiguration:
+        Type: REGIONAL
 
-  KbvQuestionRetrievalFunction:
+
+  ExperianKbvQuestionRetrievalFunction:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../lambdas/questions
@@ -52,16 +72,16 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api*'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api/experian*'
       Events:
         RetrieveQuestions:
           Type: Api
           Properties:
-            Path: /question-request
+            Path: /question_request
             Method: post
-            RestApiId: !Ref KbvApi
+            RestApiId: !Ref ExperianKbvApi
 
-  KbvQuestionAnswerFunction:
+  ExperianKbvQuestionAnswerFunction:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../lambdas/answers
@@ -77,34 +97,34 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api*'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api/experian*'
       Events:
         RetrieveQuestions:
           Type: Api
           Properties:
-            Path: /question-answer
+            Path: /question_answer
             Method: post
-            RestApiId: !Ref KbvApi
+            RestApiId: !Ref ExperianKbvApi
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   # Find out more about other implicit resources you can reference within SAM
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
-  KbvQuestionRetrievalApi:
+  ExperianKbvQuestionRetrievalApi:
     Description: "API Gateway endpoint URL for Prod stage for question retrieval function"
-    Value: !Sub "https://${KbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question-request/"
-  KbvQuestionRetrievalFunction:
+    Value: !Sub "https://${ExperianKbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question_request/"
+  ExperianKbvQuestionRetrievalFunction:
     Description: "Question retrieval lambda function ARN"
-    Value: !GetAtt KbvQuestionRetrievalFunction.Arn
-  KbvQuestionRetrievalFunctionIamRole:
+    Value: !GetAtt ExperianKbvQuestionRetrievalFunction.Arn
+  ExperianKbvQuestionRetrievalFunctionIamRole:
     Description: "Implicit IAM Role created for question retrieval function"
-    Value: !GetAtt KbvQuestionRetrievalFunction.Arn
-  KbvQuestionAnswerApi:
+    Value: !GetAtt ExperianKbvQuestionRetrievalFunction.Arn
+  ExperianKbvQuestionAnswerApi:
     Description: "API Gateway endpoint URL for Prod stage for question answer function"
-    Value: !Sub "https://${KbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question-answer/"
-  KbvQuestionAnswerFunction:
+    Value: !Sub "https://${ExperianKbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question_answer/"
+  ExperianKbvQuestionAnswerFunction:
     Description: "Question answer lambda function ARN"
-    Value: !GetAtt KbvQuestionAnswerFunction.Arn
-  KbvQuestionAnswerFunctionIamRole:
+    Value: !GetAtt ExperianKbvQuestionAnswerFunction.Arn
+  ExperianKbvQuestionAnswerFunctionIamRole:
     Description: "Implicit IAM Role created for question answer function"
-    Value: !GetAtt KbvQuestionAnswerFunction.Arn
+    Value: !GetAtt ExperianKbvQuestionAnswerFunction.Arn

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -77,7 +77,7 @@ Resources:
         RetrieveQuestions:
           Type: Api
           Properties:
-            Path: /question_request
+            Path: /question-request
             Method: post
             RestApiId: !Ref ExperianKbvApi
 
@@ -102,7 +102,7 @@ Resources:
         RetrieveQuestions:
           Type: Api
           Properties:
-            Path: /question_answer
+            Path: /question-answer
             Method: post
             RestApiId: !Ref ExperianKbvApi
 
@@ -112,7 +112,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   ExperianKbvQuestionRetrievalApi:
     Description: "API Gateway endpoint URL for Prod stage for question retrieval function"
-    Value: !Sub "https://${ExperianKbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question_request/"
+    Value: !Sub "https://${ExperianKbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question-request/"
   ExperianKbvQuestionRetrievalFunction:
     Description: "Question retrieval lambda function ARN"
     Value: !GetAtt ExperianKbvQuestionRetrievalFunction.Arn
@@ -121,7 +121,7 @@ Outputs:
     Value: !GetAtt ExperianKbvQuestionRetrievalFunction.Arn
   ExperianKbvQuestionAnswerApi:
     Description: "API Gateway endpoint URL for Prod stage for question answer function"
-    Value: !Sub "https://${ExperianKbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question_answer/"
+    Value: !Sub "https://${ExperianKbvApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/question-answer/"
   ExperianKbvQuestionAnswerFunction:
     Description: "Question answer lambda function ARN"
     Value: !GetAtt ExperianKbvQuestionAnswerFunction.Arn

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -10,11 +10,6 @@ Globals:
     Runtime: java11
     MemorySize: 512
     Tracing: Active
-    VpcConfig:
-      SecurityGroupIds:
-        - sg-0baf479c53ac54f59
-      SubnetIds:
-        - subnet-08cd07453da63f873
 
 Parameters:
   Environment:
@@ -27,6 +22,14 @@ Parameters:
       - integration
       - prod
     ConstraintDescription: specify dev, staging, integration or prod for environment
+
+Mappings:
+  Environments:
+    dev:
+      Subnets:
+        - subnet-08cd07453da63f873
+      SecurityGroup:
+        - sg-0baf479c53ac54f59
 
 Resources:
 
@@ -73,6 +76,9 @@ Resources:
               Action:
                 - 'secretsmanager:GetSecretValue'
               Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api/experian*'
+      VpcConfig:
+        SecurityGroupIds: !FindInMap [ Environments, !Ref Environment, SecurityGroup ]
+        SubnetIds: !FindInMap [ Environments, !Ref Environment, Subnets ]
       Events:
         RetrieveQuestions:
           Type: Api
@@ -98,6 +104,9 @@ Resources:
               Action:
                 - 'secretsmanager:GetSecretValue'
               Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api/experian*'
+      VpcConfig:
+        SecurityGroupIds: !FindInMap [ Environments, !Ref Environment, SecurityGroup ]
+        SubnetIds: !FindInMap [ Environments, !Ref Environment, Subnets ]
       Events:
         RetrieveQuestions:
           Type: Api

--- a/lib/src/main/java/uk/gov/di/ipv/cri/experian/kbv/api/service/KeyStoreService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/experian/kbv/api/service/KeyStoreService.java
@@ -12,8 +12,8 @@ import java.util.UUID;
 
 public class KeyStoreService {
     private final SecretsProvider secretsProvider;
-    public static final String KBV_API_KEYSTORE = "/dev/di-ipv-cri-experian-kbv-api/keystore";
-    public static final String KBV_API_KEYSTORE_PASSWORD = "/dev/di-ipv-cri-experian-kbv-api/keystore-password";
+    public static final String KBV_API_KEYSTORE = "/dev/di-ipv-cri-experian-kbv-api/experian/keystore";
+    public static final String KBV_API_KEYSTORE_PASSWORD = "/dev/di-ipv-cri-experian-kbv-api/experian/keystore-password";
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyStoreService.class);
 
     public KeyStoreService(SecretsProvider secretsProvider) {
@@ -26,7 +26,7 @@ public class KeyStoreService {
             Path tempFile = file.toPath();
             Files.write(tempFile, Base64.getDecoder().decode(secretsProvider.get(KBV_API_KEYSTORE)));
             return tempFile.toString();
-        } catch (NullPointerException | IOException e) {
+        } catch (IllegalArgumentException | NullPointerException | IOException e) {
             LOGGER.error("Initialisation failed", e);
             return null;
         }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/experian/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/experian/kbv/api/gateway/KBVGatewayTest.java
@@ -54,7 +54,7 @@ class KBVGatewayTest {
 
     @Test
     void shouldCallSubmitAnswersSuccessfully() throws InterruptedException {
-        // final String testRequestBody = "serialisedExperianKbvApiRequest";
+        // final String testRequestBody = "serialisedKbvApiRequest";
         QuestionAnswerRequest questionAnswerRequest =
                 TestDataCreator.createTestQuestionAnswerRequest();
 
@@ -80,7 +80,7 @@ class KBVGatewayTest {
         // assertEquals(TEST_API_RESPONSE_BODY, questionAnswerRequestResult);
         verify(mockResponseToQuestionMapper).mapQuestionAnswersRtqRequest(questionAnswerRequest);
         // verify(mockObjectMapper).writeValueAsString(mockRtqRequest);
-        // verify(mockExperianKbvApiConfig).getEndpointUri();
+        // verify(mockKbvApiConfig).getEndpointUri();
         // assertEquals(testEndpointUri, httpRequestCaptor.getValue().uri().toString());
         // assertEquals("POST", httpRequestCaptor.getValue().method());
         // HttpHeaders capturedHttpRequestHeaders = httpRequestCaptor.getValue().headers();
@@ -103,7 +103,7 @@ class KBVGatewayTest {
                                 null,
                                 mock(ResponseToQuestionMapper.class),
                                 mock(IdentityIQWebServiceSoap.class)),
-                        "ExperianKbvApiConfig must not be null",
+                        "kbvApiConfig must not be null",
                         new KBVGatewayTest.KbvGatewayContructorArgs(
                                 null,
                                 mock(ResponseToQuestionMapper.class),

--- a/lib/src/test/java/uk/gov/di/ipv/cri/experian/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/experian/kbv/api/gateway/KBVGatewayTest.java
@@ -54,7 +54,7 @@ class KBVGatewayTest {
 
     @Test
     void shouldCallSubmitAnswersSuccessfully() throws InterruptedException {
-        // final String testRequestBody = "serialisedKbvApiRequest";
+        // final String testRequestBody = "serialisedExperianKbvApiRequest";
         QuestionAnswerRequest questionAnswerRequest =
                 TestDataCreator.createTestQuestionAnswerRequest();
 
@@ -80,7 +80,7 @@ class KBVGatewayTest {
         // assertEquals(TEST_API_RESPONSE_BODY, questionAnswerRequestResult);
         verify(mockResponseToQuestionMapper).mapQuestionAnswersRtqRequest(questionAnswerRequest);
         // verify(mockObjectMapper).writeValueAsString(mockRtqRequest);
-        // verify(mockKbvApiConfig).getEndpointUri();
+        // verify(mockExperianKbvApiConfig).getEndpointUri();
         // assertEquals(testEndpointUri, httpRequestCaptor.getValue().uri().toString());
         // assertEquals("POST", httpRequestCaptor.getValue().method());
         // HttpHeaders capturedHttpRequestHeaders = httpRequestCaptor.getValue().headers();
@@ -103,7 +103,7 @@ class KBVGatewayTest {
                                 null,
                                 mock(ResponseToQuestionMapper.class),
                                 mock(IdentityIQWebServiceSoap.class)),
-                        "kbvApiConfig must not be null",
+                        "ExperianKbvApiConfig must not be null",
                         new KBVGatewayTest.KbvGatewayContructorArgs(
                                 null,
                                 mock(ResponseToQuestionMapper.class),


### PR DESCRIPTION

## Proposed changes

Specify an OpenAPI document for the defined API Gateway

### What changed

Experian KBV api is currently defined solely using SAM serverless API and Events, the change is to provide an OpenAPI document to describe this API

NB: Renamed resources in template file to distinguish them from KBV API

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

Defining an OpenAPI, would make the API easier to understand by consumers

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
Related to [KBV-101](https://govukverify.atlassian.net/browse/KBV-101) and  [KBV-102](https://govukverify.atlassian.net/browse/KBV-102) done
See also: [KBV-214](https://govukverify.atlassian.net/browse/KBV-101) yet to be done

This PR is based on [KBV-192](https://govukverify.atlassian.net/browse/KBV-192)
