### PR TITLE
Bau specify default task in gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,3 +37,5 @@ sonarqube {
 		property "sonar.host.url", "https://sonarcloud.io"
 	}
 }
+
+defaultTasks 'clean', 'spotlessApply', 'spotlessGroovyGradleApply', 'build'


### PR DESCRIPTION
## Proposed changes

Specify default gradle task


### Why did it change

Make it more convenient by just running `./gradlew` would ensure spotless task are run and fix if there are violations
