### PR TITLE
[KBV-177] fix gradle build and only build on pr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Build
 on:
-  # push:
-  #   branches:
-  #     - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "::set-output name=profile::$(aws ssm get-parameter --region ${{ env.AWS_REGION }} --name '${{ secrets.AWS_PROFILE_PATH }}' | jq '.Parameter.Value')"
 
       - name: Gradle build
-        run: ./gradlew clean build buildZip
+        run: ./gradlew clean build
 
       - name: SAM build
         run: sam build -t template.yaml --config-env ${{ env.ENVIRONMENT }}


### PR DESCRIPTION
## Proposed changes

### What changed

Remove buildZip from the gradle build targets as not included as a task in the gradle build file.
Change build workflow to only run on PR

### Why did it change

The gradle build file for this API does not have or require the buildZip task.
The deploy workflow also includes the build but not the sonar scanning. As the code has already been scanned on PR there is no requirement to re-run the build post PR approval.

### Issue tracking

- [KBV-177](https://govukverify.atlassian.net/browse/KBV-177)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

None